### PR TITLE
Remove *.jar and *.war from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@
 .mtj.tmp/
 
 # Package Files #
-*.jar
-*.war
 *.nar
 *.ear
 *.zip
@@ -90,7 +88,6 @@ local.properties
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-*.jar
 !gradle-wrapper.jar
 
 # User local IDEA configuration files


### PR DESCRIPTION
Removed jar and war files from the gitignore so those files will propogate appropriately.